### PR TITLE
Remove temp file in render_xml

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -59,8 +59,6 @@ class DocxTemplate(object):
         return src_xml
 
     def render_xml(self,src_xml,context):
-        with open('/tmp/titi','w') as fh:
-            fh.write(src_xml)
         template = Template(src_xml)
         dst_xml = template.render(context)
         dst_xml = dst_xml.replace('{_{','{{').replace('}_}','}}').replace('{_%','{%').replace('%_}','%}')


### PR DESCRIPTION
The tempfile `/tmp/titi` does not appear to be used elsewhere in the code. It creates however a compatibility problem in Windows. I suggest it should be removed.