### PR TITLE
Fix bug with enter in RichText.

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -172,7 +172,7 @@ class RichText(object):
 
         if not isinstance(text, six.text_type):
             text = text.decode('utf-8',errors='ignore')
-        text = escape(text).replace('\n','<w:br/>').replace('\a','</w:t></w:r></w:p><w:p><w:r><w:t xml:space="preserve">')
+        text = escape(text).replace('\n','</w:t><w:br/><w:t>').replace('\a','</w:t></w:r></w:p><w:p><w:r><w:t xml:space="preserve">')
 
         prop = u''
 


### PR DESCRIPTION
The character \n is not escaped correctly, which causes that the line break does not appear in any office version.
(Open office, Libre office or Microsoft office).
In my case, this fixed that problem.