### PR TITLE
get variables list method added

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -42,6 +42,14 @@ class DocxTemplate(object):
     def get_docx(self):
         return self.docx
 
+    def get_variables(self):
+        doc_tags = []
+        for p in self.docx.paragraphs:
+            tags = re.findall(r'\{\{(.+?)\}\}', p.text)
+            for tag in tags:
+                doc_tags.append(tag.replace(' ', ''))
+        return doc_tags
+
     def get_xml(self):
         return self.xml_to_string(self.docx._element.body)
 


### PR DESCRIPTION
We add get_variables method to DocxTemplate class, so now people can get list of all used variables in the document. Its very helpfull when you work with doc generation, when some variables can be filled automatically and some need to fill by human