### PR TITLE
Fix test incompatibility with Python 3 versions

### DIFF
--- a/tests/template_error.py
+++ b/tests/template_error.py
@@ -13,7 +13,7 @@ try:
 except TemplateError as the_error:
     six.print_(six.text_type(the_error))
     if hasattr(the_error, 'docx_context'):
-        print "Context:"
+        six.print_("Context:")
         for line in the_error.docx_context:
             six.print_(line)
 tpl.save('test_files/template_error.docx')


### PR DESCRIPTION
I've replaced `print` instruction with call of a `six` package's implementation compatible with Python 2 as well as Python 3.