### PR TITLE
Fix invalid xml parse because using {%vm%}

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -189,7 +189,8 @@ class DocxTemplate(object):
     # using of TC tag in for cycle can cause that count of columns does not correspond to
     # real count of columns in row. This function is able to fix it.
     def fix_tables(self, xml):
-        tree = etree.fromstring(xml)
+        parser = etree.XMLParser(recover=True)
+        tree = etree.fromstring(xml, parser=parser)
         # get namespace
         ns = '{' + tree.nsmap['w'] + '}'
         # walk trough xml and find table


### PR DESCRIPTION
 xml tag has't close valid tag <w:pPr>
![screenshot from 2018-10-16 15-34-44](https://user-images.githubusercontent.com/7200425/47003304-23570480-d159-11e8-922a-7a6007becc6f.png)
