### PR TITLE
Explicitly specify utf-8 encoding when opening file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ News
 
 def get_version(pkg):
     path = os.path.join(os.path.dirname(__file__),pkg,'__init__.py')
-    with open(path) as fh:
+    with open(path, encoding='utf-8') as fh:
         m = re.search(r'^__version__\s*=\s*[\'"]([^\'"]+)[\'"]',fh.read(),re.M)
     if m:
         return m.group(1)


### PR DESCRIPTION
When creating a conda package from the package on pypi, setup.py crashes in `get_version(pkg)` due to choking on an `\x9d` while reading `__init__.py`. Apparently because on Windows, the default encoding `open()` isn't UTF-8... instead it tries using [CP-1252](https://en.wikipedia.org/wiki/Windows-1252) and `\x9d` has no meaning in CP-1252. 

Explicitly specifying UTF-8 encoding in `open()` fixes this.

Similar to
https://stackoverflow.com/a/9233174/119775
and
https://stackoverflow.com/a/31838862/119775