### PR TITLE
Fix need to "Recover document" after using replace_media and saving to file-like object

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -456,8 +456,9 @@ class DocxTemplate(object):
 
             if hasattr(docx_file, 'read'):
                 tmp_file = io.BytesIO()
-                Document(docx_file).save(tmp_file)
+                DocxTemplate(docx_file).save(tmp_file)
                 tmp_file.seek(0)
+                docx_file.seek(0)
 
             else:
                 tmp_file = '%s_docxtpl_before_replace_medias' % docx_file

--- a/tests/header_footer_image_file_obj.py
+++ b/tests/header_footer_image_file_obj.py
@@ -32,4 +32,6 @@ tpl.render(context)
 file_obj = io.BytesIO()
 tpl.save(file_obj)
 file_obj.seek(0)
-DocxTemplate(file_obj).save(DEST_FILE2)
+with open(DEST_FILE2, 'wb') as f:
+    f.write(file_obj.read())
+


### PR DESCRIPTION
Sorry, this was actually supposed to be part of the original PR for file-like object support. I thought Github automatically updated PRs based on forks.

The test better outline saving to file-like objects without any modifications outside of docxtpl