### PR TITLE
Truncate zip file before re-writing it for  replace_media with file-like objects

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -463,6 +463,8 @@ class DocxTemplate(object):
                 DocxTemplate(docx_file).save(tmp_file)
                 tmp_file.seek(0)
                 docx_file.seek(0)
+                docx_file.truncate()
+                docx_file.seek(0)
 
             else:
                 tmp_file = '%s_docxtpl_before_replace_medias' % docx_file


### PR DESCRIPTION
Adding a truncation to the file object that is passed. This makes sure that the zip file's table of contents is re-written after the new pictures have been added. If the picture size changed too much the table of contents would be incorrect causing Microsoft word to have to open the document in recovery mode and fix the zip file. This fixes that issue.