### PR TITLE
Allow jinja environment to be passed to undeclared_template_variables

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -558,7 +558,7 @@ class DocxTemplate(object):
         self.docx.save(filename,*args,**kwargs)
         self.post_processing(filename)
 
-    def undeclared_template_variables(self, jinja_env=None):
+    def get_undeclared_template_variables(self, jinja_env=None):
         xml = self.get_xml()
         xml = self.patch_xml(xml)
         if jinja_env:
@@ -567,6 +567,8 @@ class DocxTemplate(object):
             env = Environment()
         parse_content = env.parse(xml)
         return meta.find_undeclared_variables(parse_content)
+
+    undeclared_template_variables = property(get_undeclared_template_variables)
 
 
 class Subdoc(object):

--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -558,11 +558,13 @@ class DocxTemplate(object):
         self.docx.save(filename,*args,**kwargs)
         self.post_processing(filename)
 
-    @property
-    def undeclared_template_variables(self):
+    def undeclared_template_variables(self, jinja_env=None):
         xml = self.get_xml()
         xml = self.patch_xml(xml)
-        env = Environment()
+        if jinja_env:
+            env = jinja_env
+        else:
+            env = Environment()
         parse_content = env.parse(xml)
         return meta.find_undeclared_variables(parse_content)
 


### PR DESCRIPTION
Fixes #208 
Changes `undeclared_template_variables` to be a method instead of property.