### PR TITLE
Add the ability to add a RichText object to another RichText object

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -625,6 +625,10 @@ class RichText(object):
                         font=None,
                         url_id=None):
 
+        # If a RichText is added
+        if isinstance(text, RichText):
+            self.xml += text.xml
+            return
 
         # If not a string : cast to string (ex: int, dict etc...)
         if not isinstance(text, (six.text_type, six.binary_type)):

--- a/tests/richtext.py
+++ b/tests/richtext.py
@@ -9,7 +9,7 @@ from docxtpl import DocxTemplate, RichText
 
 tpl=DocxTemplate('templates/richtext_tpl.docx')
 
-rt = RichText('an exemple of ')
+rt = RichText()
 rt.add('a rich text', style='myrichtextstyle')
 rt.add(' with ')
 rt.add('some italic', italic=True)
@@ -38,8 +38,11 @@ rt.add('superscript', superscript=True)
 rt.add(' and some')
 rt.add('subscript', subscript=True)
 
+rt_embedded = RichText('an example of ')
+rt_embedded.add(rt)
+
 context = {
-    'example' : rt,
+    'example' : rt_embedded,
 }
 
 tpl.render(context)


### PR DESCRIPTION
Hi,

First, thank you for sharing your library.

This PR allows to add a RichText object to another one. I use this in case in which some sentences parts are computed by a function. Example : 

<pre>def generate_rt_people(people):
	rt = RichText()
	rt.add("{} ".format(people.firstname))
	rt.add(people.lastname, bold=True, underline=True)

	return rt

two_peoples = RichText()
two_peoples .add(people1)
two_peoples .add(' and ')
two_peoples .add(people2)</pre>