### PR TITLE
Prevent lxml from attempting to parse None

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -236,7 +236,7 @@ class DocxTemplate(object):
 
     def get_headers_footers_xml(self, uri):
         for relKey, val in self.docx._part._rels.items():
-            if val.reltype == uri:
+            if (val.reltype == uri) and (val._target._blob):
                 yield relKey, self.xml_to_string(parse_xml(val._target._blob))
 
     def get_headers_footers_encoding(self,xml):


### PR DESCRIPTION
Using Python 3.8.2, lxml 4.5.0 , tests failed with the following traceback:

```
Traceback (most recent call last):
  File "./custom_jinja_filters.py", line 32, in <module>
    tpl.render(context, jinja_env)
  File "/Users/x/src/python-docx-template/docxtpl/__init__.py", line 276, in render
    for relKey, xml in headers:
  File "/Users/x/src/python-docx-template/docxtpl/__init__.py", line 249, in build_headers_footers_xml
    for relKey, xml in self.get_headers_footers_xml(uri):
  File "/Users/x/src/python-docx-template/docxtpl/__init__.py", line 240, in get_headers_footers_xml
    yield relKey, self.xml_to_string(parse_xml(val._target._blob))
  File "/Users/x/.pyenv/versions/3.8.2/Python.framework/Versions/3.8/lib/python3.8/site-packages/docx/opc/oxml.py", line 37, in parse_xml
    return etree.fromstring(text, oxml_parser)
  File "src/lxml/etree.pyx", line 3235, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1875, in lxml.etree._parseMemoryDocument
ValueError: can only parse strings
```
Added check to make sure `val._target._blob` exists before calling `self.xml_to_string`