### PR TITLE
Make headers and footers work with both python-docx 0.8.7 and 0.8.10

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -12,6 +12,7 @@ __version__ = '0.6.4'
 from lxml import etree
 from docx import Document
 from docx.opc.oxml import serialize_part_xml, parse_xml
+from docx.opc.part import XmlPart
 import docx.oxml.ns
 from docx.opc.constants import RELATIONSHIP_TYPE as REL_TYPE
 from jinja2 import Environment, Template, meta
@@ -236,8 +237,8 @@ class DocxTemplate(object):
 
     def get_headers_footers_xml(self, uri):
         for relKey, val in self.docx._part._rels.items():
-            if (val.reltype == uri) and (val._target._blob):
-                yield relKey, self.xml_to_string(parse_xml(val._target._blob))
+            if (val.reltype == uri) and (val.target_part.blob):
+                yield relKey, self.xml_to_string(parse_xml(val.target_part.blob))
 
     def get_headers_footers_encoding(self,xml):
         m = re.match(r'<\?xml[^\?]+\bencoding="([^"]+)"',xml,re.I)
@@ -253,7 +254,8 @@ class DocxTemplate(object):
             yield relKey, xml.encode(encoding)
 
     def map_headers_footers_xml(self, relKey, xml):
-        self.docx._part._rels[relKey]._target._blob = xml
+        part = self.docx._part._rels[relKey].target_part
+        self.docx._part._rels[relKey]._target = XmlPart.load(part.partname, part.content_type, xml, part.package)
 
     def render(self, context, jinja_env=None, autoescape=False):
         if autoescape:

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='docxtpl',
       license='LGPL 2.1',
       packages=['docxtpl'],
       install_requires=['six',
-                        'python-docx<=0.8.7', # newer docx package breaks header/footer management in docxtpl
+                        'python-docx',
                         'jinja2',
                         'lxml'],
       extras_require={'docs': ['Sphinx', 'sphinxcontrib-napoleon']},


### PR DESCRIPTION
This fixes headers and footers for me in both 0.8.7 and 0.8.10. Fixes #246 

It does the following:

- Use proper properties (`target_part` and `blob`) in `get_headers_footers_xml`
- Replace the `Relationship` target using `XmlPart.load`

Problems:

- Image replacement in headers (all tests regarding this) does not work for me in 0.8.7 and the behaviour is the same in 0.8.10. I assume this was already broken.

Please let me know if this change looks good to you.