### PR TITLE
Make headers and footers work with both python-docx 0.8.7 and 0.8.10 #2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(name='docxtpl',
       license='LGPL 2.1',
       packages=['docxtpl'],
       install_requires=['six',
-                        'python-docx<=0.8.7', # newer docx package breaks header/footer management in docxtpl
+                        'python-docx',
                         'jinja2',
                         'lxml'],
       extras_require={'docs': ['Sphinx', 'sphinxcontrib-napoleon']},


### PR DESCRIPTION
Attempt 2 - see #263 . Fixes #246 .

There was indeed something wrong with my old attempt. I've copied the rels into the newly created part in this attempt.

![image](https://user-images.githubusercontent.com/627551/78913778-cc01ce00-7a89-11ea-9a34-f76b5f34447c.png)

Note that these changes use only public API (no `_` or `__` functions/properties) so hopefully they are more forwards compatible than the old code.


PS. Please don't merge this unless you are convinced this one is correct, that is easier for both of us.