### PR TITLE
docs: Fix simple typo, embdded -> embedded

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -311,7 +311,7 @@ Instead, you should use zipname replacement::
 The zipname is the one you can find when you open docx with WinZip, 7zip (Windows) or unzip -l (Linux).
 The zipname starts with "word/embeddings/". Note that the file to be replaced is renamed by MSWord, so you have to guess a little bit...
 
-This works for embdded MSWord file like Excel or PowerPoint file, but won't work for others like PDF, Python or even Text files :
+This works for embedded MSWord file like Excel or PowerPoint file, but won't work for others like PDF, Python or even Text files :
 For these ones, MSWord generate an oleObjectNNN.bin file which is no use to be replaced as it is encoded.
 
 

--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -450,7 +450,7 @@ class DocxTemplate(object):
                 self.pic_to_replace[embedded_file] = fh.read()
 
     def replace_embedded(self, src_file, dst_file):
-        """Replace one embdded object by another one into a docx
+        """Replace one embedded object by another one into a docx
 
         This has been done mainly because it is not possible to add images
         in docx header/footer.
@@ -477,7 +477,7 @@ class DocxTemplate(object):
         the template : thus replace_embedded() cannot be used as CRC is not the
         same as the original file.
 
-        This method works for embdded MSWord file like Excel or PowerPoint file,
+        This method works for embedded MSWord file like Excel or PowerPoint file,
         but won't work for others like PDF, Python or even Text files :
         For these ones, MSWord generate an oleObjectNNN.bin file which is no
         use to be replaced as it is encoded.


### PR DESCRIPTION
There is a small typo in docs/index.rst, docxtpl/__init__.py.

Should read `embedded` rather than `embdded`.

