### PR TITLE
Add conda install instructions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,9 +8,13 @@ Welcome to python-docx-template's documentation!
 
 .. rubric:: Quickstart
 
-To install::
+To install using pip::
 
     pip install docxtpl
+
+or using conda::
+
+    conda install docxtpl --channel conda-forge
 
 Usage::
 


### PR DESCRIPTION
Hi, some time back I added a feedstock on conda-forge so that docxtpl can also be installed from there. I maintain it. 
https://github.com/conda-forge/docxtpl-feedstock

In this PR, I simply added the instructions for how to install using conda. 