### PR TITLE
Line break with styles preserving

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -818,8 +818,9 @@ class InlineImage(object):
             self.width,
             self.height
         ).xml
-        return '</w:t></w:r><w:r><w:drawing>%s</w:drawing></w:r><w:r>' \
+        xml = '</w:t></w:r><w:r><w:drawing>%s</w:drawing></w:r><w:r>' \
                '<w:t xml:space="preserve">' % pic
+        return re.sub(r'\n *', '', xml)
 
     def __unicode__(self):
         return self._insert_image()

--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -239,16 +239,23 @@ class DocxTemplate(object):
         return dst_xml
 
     def resolve_listing(self, xml):
-        xml = xml.replace('\n', NEWLINE_XML)
-        xml = xml.replace('\f', PAGE_BREAK)
+
+        def resolve_text(run_properties, paragraph_properties, m):
+            xml = m[0].replace('\t', '</w:t></w:r>'
+                                     '<w:r>%s<w:tab/></w:r>'
+                                     '<w:r>%s<w:t xml:space="preserve">' % (run_properties, run_properties))
+            xml = xml.replace('\a', '</w:t></w:r></w:p>'
+                                    '<w:p>%s<w:r>%s<w:t xml:space="preserve">' % (paragraph_properties, run_properties))
+            xml = xml.replace('\n', NEWLINE_XML)
+            xml = xml.replace('\f', PAGE_BREAK)
+            return xml
 
         def resolve_run(paragraph_properties, m):
             run_properties = re.search(r'<w:rPr>.*</w:rPr>', m[0])
             run_properties = run_properties[0] if run_properties else ''
-            xml = m[0].replace('\t', '</w:t></w:r>'
-                                     '<w:r>%s<w:tab/></w:r>'
-                                     '<w:r>%s<w:t xml:space="preserve">' % (run_properties, run_properties))
-            return xml.replace('\a', '</w:t></w:r></w:p><w:p>%s<w:r>%s<w:t>' % (paragraph_properties, run_properties))
+
+            p_resolve_text = partial(partial(resolve_text, run_properties), paragraph_properties)
+            return re.sub(r'<w:t(?: [^>]*)?>.*?</w:t>', p_resolve_text, m[0], flags=re.DOTALL)
 
         def resolve_paragraph(m):
             paragraph_properties = re.search(r'<w:pPr>.*</w:pPr>', m[0])
@@ -256,9 +263,9 @@ class DocxTemplate(object):
 
             p_resolve_run = partial(resolve_run, paragraph_properties)
 
-            return re.sub(r'<w:r(?: [^>]*)?>.*?</w:r>', p_resolve_run, m[0])
+            return re.sub(r'<w:r(?: [^>]*)?>.*?</w:r>', p_resolve_run, m[0], flags=re.DOTALL)
 
-        xml = re.sub(r'<w:p(?: [^>]*)?>.*?</w:p>', resolve_paragraph, xml)
+        xml = re.sub(r'<w:p(?: [^>]*)?>.*?</w:p>', resolve_paragraph, xml, flags=re.DOTALL)
 
         return xml
 

--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -240,13 +240,15 @@ class DocxTemplate(object):
 
     def resolve_listing(self, xml):
         xml = xml.replace('\n', NEWLINE_XML)
-        xml = xml.replace('\t', TAB_XML)
         xml = xml.replace('\f', PAGE_BREAK)
 
         def resolve_run(paragraph_properties, m):
             run_properties = re.search(r'<w:rPr>.*</w:rPr>', m[0])
             run_properties = run_properties[0] if run_properties else ''
-            return m[0].replace('\a', '</w:t></w:r></w:p><w:p>%s<w:r>%s<w:t>' % (paragraph_properties, run_properties))
+            xml = m[0].replace('\t', '</w:t></w:r>'
+                                     '<w:r>%s<w:tab/></w:r>'
+                                     '<w:r>%s<w:t xml:space="preserve">' % (run_properties, run_properties))
+            return xml.replace('\a', '</w:t></w:r></w:p><w:p>%s<w:r>%s<w:t>' % (paragraph_properties, run_properties))
 
         def resolve_paragraph(m):
             paragraph_properties = re.search(r'<w:pPr>.*</w:pPr>', m[0])

--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -717,12 +717,7 @@ class RichText(object):
             text = six.text_type(text)
         if not isinstance(text, six.text_type):
             text = text.decode('utf-8', errors='ignore')
-        text = (escape(text)
-                .replace('\n', NEWLINE_XML)
-                .replace('\a', NEWPARAGRAPH_XML)
-                .replace('\t', TAB_XML)
-                .replace('\f', PAGE_BREAK))
-
+        text = escape(text)
         prop = u''
 
         if style:


### PR DESCRIPTION
Fixed #313 and tested on Word 2019

Rich text saves paragraph style.
![image](https://user-images.githubusercontent.com/24554619/96354416-086c5180-10df-11eb-9afb-4b742cd295c9.png)
It is acceptable behavior for reach text?