### PR TITLE
For better error messages, allow there to be additional attributes on paragraphs …

### DIFF
--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -225,7 +225,7 @@ class DocxTemplate(object):
                 exc.docx_context = map(lambda x: re.sub(r'<[^>]+>', '', x),
                                        src_xml.splitlines()[line_number:(line_number + 7)])
             raise exc
-        dst_xml = dst_xml.replace('\n<w:p>', '<w:p>')
+        dst_xml = dst_xml.replace('\n<w:p ', '<w:p ')
         dst_xml = (dst_xml
                    .replace('{_{', '{{')
                    .replace('}_}', '}}')

--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -211,7 +211,7 @@ class DocxTemplate(object):
         return src_xml
 
     def render_xml_part(self, src_xml, part, context, jinja_env=None):
-        src_xml = src_xml.replace(r'<w:p>', '\n<w:p>')
+        src_xml = src_xml.replace(r'<w:p ', '\n<w:p ')
         try:
             self.current_rendering_part = part
             if jinja_env:


### PR DESCRIPTION
…  Documents created in some versions of word will have paragraph tags in the form <w:p w14:paraId=7784C09A ... and so forth.  The render_xml_part does not find these paragraph tags, and in some cases creates no lines breaks at all, making error messages impossible to decipher in large documents.