### PR TITLE
Add first type hints

### DIFF
--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -6,7 +6,7 @@ Created : 2015-03-12
 """
 
 from os import PathLike
-from typing import Any, Optional, IO, Union, Dict
+from typing import Any, Optional, IO, Union, Dict, Set
 from .subdoc import Subdoc
 import functools
 import io
@@ -36,7 +36,7 @@ class DocxTemplate(object):
     HEADER_URI = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header"
     FOOTER_URI = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer"
 
-    def __init__(self, template_file_or_path: Union[IO[bytes], str, PathLike[str]]):
+    def __init__(self, template_file_or_path: Union[IO[bytes], str, PathLike[str]]) -> None:
         self.template_file_or_path = template_file_or_path
         self.reset_replacements()
         self.docx = None
@@ -324,7 +324,7 @@ class DocxTemplate(object):
             new_part.load_rel(rel.reltype, rel._target, rel.rId, rel.is_external)
         self.docx._part._rels[relKey]._target = new_part
 
-    def render(self, context: Dict[str, Any], jinja_env: Optional[Environment]=None, autoescape: bool=False):
+    def render(self, context: Dict[str, Any], jinja_env: Optional[Environment]=None, autoescape: bool=False) -> None:
         # init template working attributes
         self.render_init()
 
@@ -722,7 +722,7 @@ class DocxTemplate(object):
         self.post_processing(output_file_or_path)
         self.is_saved = True
 
-    def get_undeclared_template_variables(self, jinja_env=None):
+    def get_undeclared_template_variables(self, jinja_env: Optional[Environment]=None) -> Set[str]:
         self.init_docx()
         xml = self.get_xml()
         xml = self.patch_xml(xml)

--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -36,8 +36,8 @@ class DocxTemplate(object):
     HEADER_URI = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/header"
     FOOTER_URI = "http://schemas.openxmlformats.org/officeDocument/2006/relationships/footer"
 
-    def __init__(self, template_file_or_path: Union[IO[bytes], str, PathLike[str]]) -> None:
-        self.template_file_or_path = template_file_or_path
+    def __init__(self, template_file: Union[IO[bytes], str, PathLike[str]]) -> None:
+        self.template_file = template_file
         self.reset_replacements()
         self.docx = None
         self.is_rendered = False
@@ -45,7 +45,7 @@ class DocxTemplate(object):
 
     def init_docx(self):
         if not self.docx or self.is_rendered:
-            self.docx = Document(self.template_file_or_path)
+            self.docx = Document(self.template_file)
             self.is_rendered = False
 
     def render_init(self):
@@ -712,14 +712,14 @@ class DocxTemplate(object):
         return self.docx._part.relate_to(url, REL_TYPE.HYPERLINK,
                                          is_external=True)
 
-    def save(self, output_file_or_path: Union[IO[bytes], str, PathLike[str]], *args, **kwargs):
+    def save(self, filename: Union[IO[bytes], str, PathLike[str]], *args, **kwargs):
         # case where save() is called without doing rendering
         # ( user wants only to replace image/embedded/zipname )
         if not self.is_saved and not self.is_rendered:
-            self.docx = Document(self.template_file_or_path)
+            self.docx = Document(self.template_file)
         self.pre_processing()
-        self.docx.save(output_file_or_path, *args, **kwargs)
-        self.post_processing(output_file_or_path)
+        self.docx.save(filename, *args, **kwargs)
+        self.post_processing(filename)
         self.is_saved = True
 
     def get_undeclared_template_variables(self, jinja_env: Optional[Environment]=None) -> Set[str]:

--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -712,7 +712,7 @@ class DocxTemplate(object):
         return self.docx._part.relate_to(url, REL_TYPE.HYPERLINK,
                                          is_external=True)
 
-    def save(self, filename: Union[IO[bytes], str, PathLike[str]], *args, **kwargs):
+    def save(self, filename: Union[IO[bytes], str, PathLike[str]], *args, **kwargs) -> None:
         # case where save() is called without doing rendering
         # ( user wants only to replace image/embedded/zipname )
         if not self.is_saved and not self.is_rendered:


### PR DESCRIPTION
Those type hints are minimum which makes library easier to use. I can add more type hints (internal type hints) after this is merged.