### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -254,7 +254,7 @@ just add ``{{ <var> }}`` tag in your template where ``<var>`` is an instance of 
 
    myimage = InlineImage(tpl, image_descriptor='test_files/python_logo.png', width=Mm(20), height=Mm(10))
 
-You just have to specify the template object, the image file path and optionnally width and/or height.
+You just have to specify the template object, the image file path and optionally width and/or height.
 For height and width you have to use millimeters (Mm), inches (Inches) or points(Pt) class.
 Please see tests/inline_image.py for an example.
 
@@ -265,7 +265,7 @@ A template variable can contain a complex and built from scratch with python-doc
 To do so, get first a sub-document object from template object and use it as a python-docx document object,
 see example in `tests/subdoc.py`.
 
-Since docxtpl V0.12.0, it is now possible to merge an exsting .docx as a subdoc, just specify its path when
+Since docxtpl V0.12.0, it is now possible to merge an existing .docx as a subdoc, just specify its path when
 calling method `new_subdoc()` ::
 
    tpl = DocxTemplate('templates/merge_docx_master_tpl.docx')
@@ -342,10 +342,10 @@ It works like medias replacement, except it is for embedded objects like embedde
 
 Syntax to replace embedded_dummy.docx::
 
-   tpl.replace_embedded('embdded_dummy.docx','embdded_docx_i_want.docx')
+   tpl.replace_embedded('embedded_dummy.docx','embedded_docx_i_want.docx')
 
 
-WARNING : unlike replace_pic() method, embdded_dummy.docx MUST exist in the template directory when rendering and saving the generated docx. It must be the same
+WARNING : unlike replace_pic() method, embedded_dummy.docx MUST exist in the template directory when rendering and saving the generated docx. It must be the same
 file as the one inserted manually in the docx template.
 The replacement occurs in headers, footers and the whole document's body.
 
@@ -369,7 +369,7 @@ Microsoft Word 2016 special cases
 
 MS Word 2016 will ignore ``\t`` tabulations. This is special to that version.
 Libreoffice or Wordpad do not have this problem. The same thing occurs for line
-beginning with a jinja2 tag provinding spaces : They will be ignored.
+beginning with a jinja2 tag providing spaces : They will be ignored.
 To solve these problem, the solution is to use Richtext::
 
    tpl.render({
@@ -400,7 +400,7 @@ You can also merge cells vertically within a for loop (see tests/vertical_merge.
 Jinja custom filters
 --------------------
 
-``render()`` accepts ``jinja_env`` optionnal argument : you may pass a jinja environment object.
+``render()`` accepts ``jinja_env`` optional argument : you may pass a jinja environment object.
 By this way you will be able to add some custom jinja filters::
 
     from docxtpl import DocxTemplate

--- a/docxtpl/__main__.py
+++ b/docxtpl/__main__.py
@@ -131,7 +131,7 @@ def save_file(doc, parsed_args):
 
 def main():
     parser = make_arg_parser()
-    # Everything is in a try-except block that cacthes a RuntimeError that is
+    # Everything is in a try-except block that catches a RuntimeError that is
     # raised if any of the individual functions called cause an error
     # themselves, terminating the main function.
     parsed_args = get_args(parser)

--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -75,7 +75,7 @@ class DocxTemplate(object):
             fh.write(self.get_xml())
 
     def patch_xml(self, src_xml):
-        """ Make a lots of cleanning to have a raw xml understandable by jinja2 :
+        """ Make a lots of cleaning to have a raw xml understandable by jinja2 :
         strip all unnecessary xml tags, manage table cell background color and colspan,
         unescape html entities, etc... """
 
@@ -131,7 +131,7 @@ class DocxTemplate(object):
         for y in ['tr', 'tc', 'p', 'r']:
             # replace into xml code the row/paragraph/run containing
             # {%y xxx %} or {{y xxx}} template tag
-            # by {% xxx %} or {{ xx }} without any surronding <w:y> tags :
+            # by {% xxx %} or {{ xx }} without any surrounding <w:y> tags :
             # This is mandatory to have jinja2 generating correct xml code
             pat = r'<w:%(y)s[ >](?:(?!<w:%(y)s[ >]).)*({%%|{{)%(y)s ([^}%%]*(?:%%}|}})).*?</w:%(y)s>' % {'y': y}
             src_xml = re.sub(pat, r'\1 \2', src_xml, flags=re.DOTALL)
@@ -383,7 +383,7 @@ class DocxTemplate(object):
                 cells = r.findall(ns+'tc')
                 if (len(columns) + to_add) < len(cells):
                     to_add = len(cells) - len(columns)
-            # is neccessary to add columns?
+            # is necessary to add columns?
             if to_add > 0:
                 # at first, calculate width of table according to columns
                 # (we want to preserve it)
@@ -571,7 +571,7 @@ class DocxTemplate(object):
             self.zipname_to_replace[zipname] = fh.read()
 
     def reset_replacements(self):
-        """Reset replacement dictionnaries
+        """Reset replacement dictionaries
 
         This will reset data for image/embedded/zipname replacement
 

--- a/tests/embedded.py
+++ b/tests/embedded.py
@@ -16,7 +16,7 @@ embedded_docx_tpl.render(context)
 embedded_docx_tpl.save('output/embedded_embedded_docx.docx')
 
 
-# rendring the main document :
+# rendering the main document :
 tpl = DocxTemplate('templates/embedded_main_tpl.docx')
 
 context = {


### PR DESCRIPTION
There are small typos in:
- docs/index.rst
- docxtpl/__main__.py
- docxtpl/template.py
- tests/embedded.py

Fixes:
- Should read `surrounding` rather than `surronding`.
- Should read `rendering` rather than `rendring`.
- Should read `providing` rather than `provinding`.
- Should read `optionally` rather than `optionnally`.
- Should read `optional` rather than `optionnal`.
- Should read `necessary` rather than `neccessary`.
- Should read `existing` rather than `exsting`.
- Should read `embedded` rather than `embdded`.
- Should read `dictionaries` rather than `dictionnaries`.
- Should read `cleaning` rather than `cleanning`.
- Should read `catches` rather than `cacthes`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md