### PR TITLE
fixed element properties for highlighted text

### DIFF
--- a/docxtpl/richtext.py
+++ b/docxtpl/richtext.py
@@ -60,7 +60,7 @@ class RichText(object):
         if highlight:
             if highlight[0] == '#':
                 highlight = highlight[1:]
-            prop += u'<w:highlight w:val="%s"/>' % highlight
+            prop += u'<w:shd w:fill="%s"/>' % highlight
         if size:
             prop += u'<w:sz w:val="%s"/>' % size
             prop += u'<w:szCs w:val="%s"/>' % size


### PR DESCRIPTION
When `RichText` elements are used with the `highlight` attributes, the generated document contains errors.

Fixing the xml properties seemed to produce correct documents.

Proof-of-Concept code:
```python3
from docxtpl import RichText, DocxTemplate

tpl = DocxTemplate('poc.docx')
YELLOW = 'ffe699'

normal_string = 'Lorem ipsum dolor sit amet, consectetur adipisici elit'
rich_string = 'String with a yellow highlight'

rt_embedded = RichText(f'{rich_string}', highlight=YELLOW)

context = {
    'example' : rt_embedded,
}
                
tpl.render(context)
tpl.save('richtext.docx')
```

current:

![2023-03-01 09_04_35-poc docx - Word](https://user-images.githubusercontent.com/7869385/222081279-5d358564-b3d9-4e42-b8c5-9324239cfef2.png)


![2023-03-01 09_05_55-Microsoft Word](https://user-images.githubusercontent.com/7869385/222081305-56795e50-c00d-4de2-b605-19e7962c27cc.png)


![2023-03-01 09_06_06-Dokument1 - Word](https://user-images.githubusercontent.com/7869385/222081446-d5756989-a885-4563-b7b9-21fcda652b0d.png)


fixed:

![2023-03-01 09_04_23-richtext docx - Word](https://user-images.githubusercontent.com/7869385/222081505-d6801bcf-23c9-43e2-8a8e-768814f7beb6.png)


