### PR TITLE
encode XML as bytes in render_footnotes()

### DIFF
--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -370,7 +370,7 @@ class DocxTemplate(object):
                         else part.blob
                     )
                     xml = self.render_xml_part(xml, part, context, jinja_env)
-                    part._blob = xml
+                    part._blob = xml.encode("utf-8")
 
     def resolve_listing(self, xml):
 


### PR DESCRIPTION
I got an error from `docxcompose.composer.add_footnotes()` after upgrading `docxtpl` to 0.19.0.

> ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.

I was able to avoid this error by making the change in this pull request, which ensures that the modified XML is written back to the `docx` document as `bytes`.

I'm not an authority on whether `part._blob` should be `bytes` or not, but it seems that way based on how this change fixes the problem I was having with `docxcompose`.