### PR TITLE
Handle cases like 0 input for conversion to RichText

### DIFF
--- a/docxtpl/richtext.py
+++ b/docxtpl/richtext.py
@@ -20,7 +20,7 @@ class RichText(object):
 
     def __init__(self, text=None, **text_prop):
         self.xml = ""
-        if text is None:
+        if text is not None and text != "":
             self.add(text, **text_prop)
 
     def add(


### PR DESCRIPTION
If someone wants to format numeric values as RichText they might do something like:
```
foo = 1234
rt = RichText(foo, bold=True)
```

The result is currently an object where the xml is ''. This is due to checking `if text:` rather than explicitly checking for None or "". This results that.