### PR TITLE
Fixed escaping delimiters cannot render properly

### DIFF
--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -318,11 +318,10 @@ class DocxTemplate(object):
 
             raise exc
         dst_xml = re.sub(r"\n<w:p([ >])", r"<w:p\1", dst_xml)
-        dst_xml = (
-            dst_xml.replace("{_{", "{{")
-            .replace("}_}", "}}")
-            .replace("{_%", "{%")
-            .replace("%_}", "%}")
+        dst_xml = re.sub(
+            r"([{}%])[^{}%_\f\n\r\t\v]*?_[^{}%_\f\n\r\t\v]*?([{}%])",
+            r"\1\2",
+            dst_xml
         )
         dst_xml = self.resolve_listing(dst_xml)
         return dst_xml


### PR DESCRIPTION
Fixed [issus#548](https://github.com/elapouya/python-docx-template/issues/548) 