### PR TITLE
fix: move font below style to create correct order for OOXML specs

### DIFF
--- a/docxtpl/richtext.py
+++ b/docxtpl/richtext.py
@@ -62,6 +62,14 @@ class RichText(object):
 
         if style:
             prop += '<w:rStyle w:val="%s"/>' % style
+        if font:
+            regional_font = ""
+            if ":" in font:
+                region, font = font.split(":", 1)
+                regional_font = ' w:{region}="{font}"'.format(font=font, region=region)
+            prop += '<w:rFonts w:ascii="{font}" w:hAnsi="{font}" w:cs="{font}"{regional_font}/>'.format(
+                font=font, regional_font=regional_font
+            )
         if color:
             if color[0] == "#":
                 color = color[1:]
@@ -100,14 +108,6 @@ class RichText(object):
             prop += '<w:u w:val="%s"/>' % underline
         if strike:
             prop += "<w:strike/>"
-        if font:
-            regional_font = ""
-            if ":" in font:
-                region, font = font.split(":", 1)
-                regional_font = ' w:{region}="{font}"'.format(font=font, region=region)
-            prop += '<w:rFonts w:ascii="{font}" w:hAnsi="{font}" w:cs="{font}"{regional_font}/>'.format(
-                font=font, regional_font=regional_font
-            )
         if rtl:
             prop += '<w:rtl w:val="true"/>'
         if lang:


### PR DESCRIPTION
## Description
**Problem**
The RichText.add() method generates <w:rPr> (run properties) with elements in an order that doesn't comply with the OOXML specification (ECMA-376). Currently, <w:rFonts> is added after <w:b> and <w:i>, but the spec requires <w:rFonts> to come before these formatting elements. This causes Microsoft Word to ignore the font parameter when used together with bold=True or italic=True.

**Current behavior**
rt = RichText()
rt.add("Hello", bold=True, font="Arial")
print(rt.xml)

**Output**: <w:rPr><w:b/><w:rFonts .../></w:rPr> 

**Expected behavior**: <w:rPr><w:rFonts .../><w:b/></w:rPr> 

## OOXML spec reference
The correct order for <w:rPr> child elements per ECMA-376:
rStyle, rFonts, b, bCs, i, iCs, caps, smallCaps, strike, ...

## Fix
Move the if font: block to immediately after the if style: block in richtext.py.

## Related Issues
#625 
