### PR TITLE
Fail fast on invalid rendered XML

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -327,6 +327,9 @@ especially ``<``, ``>`` and ``&``. In order to use them, you must escape them. T
 
 See tests/escape.py example for more informations.
 
+If unescaped context values make the generated XML invalid, rendering raises a ``ValueError`` instead of recovering the invalid
+XML and producing a corrupted docx.
+
 Another solution, if you want to include a listing into your document, that is to escape the text and manage ``\n``, ``\a``, and ``\f``
 you can use the ``Listing`` class :
 
@@ -532,4 +535,3 @@ Indices and tables
 * :ref:`genindex`
 * :ref:`modindex`
 * :ref:`search`
-

--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -71,6 +71,17 @@ class DocxTemplate(object):
         # won't work properly
         return etree.tostring(xml, encoding="unicode", pretty_print=False)
 
+    def _validate_xml(self, xml):
+        try:
+            etree.fromstring(xml.encode("utf-8") if isinstance(xml, str) else xml)
+        except etree.XMLSyntaxError as exc:
+            raise ValueError(
+                "Generated XML is invalid. This often happens when context "
+                "values contain unescaped '<', '>' or '&' characters. "
+                "Use the |e filter, pass autoescape=True to render(), or "
+                "use RichText/Listing where appropriate."
+            ) from exc
+
     def get_docx(self):
         self.init_docx()
         return self.docx
@@ -328,6 +339,7 @@ class DocxTemplate(object):
             .replace("%_}", "%}")
         )
         dst_xml = self.resolve_listing(dst_xml)
+        self._validate_xml(dst_xml)
         return dst_xml
 
     def render_properties(

--- a/tests/invalid_xml_after_rendering.py
+++ b/tests/invalid_xml_after_rendering.py
@@ -1,0 +1,44 @@
+from io import BytesIO
+
+from docx import Document
+
+from docxtpl import DocxTemplate
+
+
+def create_template():
+    document = Document()
+    document.add_paragraph("Criticality: {{ defect.criticality }}")
+    document.add_paragraph("Source: {{ defect.source }}")
+
+    stream = BytesIO()
+    document.save(stream)
+    stream.seek(0)
+    return stream
+
+
+def render_template(autoescape=False):
+    tpl = DocxTemplate(create_template())
+    tpl.render(
+        {"defect": {"criticality": "<select>", "source": "QA"}},
+        autoescape=autoescape,
+    )
+
+    output = BytesIO()
+    tpl.save(output)
+    output.seek(0)
+    return Document(output)
+
+
+try:
+    render_template()
+except ValueError as exc:
+    assert "Generated XML is invalid" in str(exc)
+else:
+    raise AssertionError("Unescaped XML should raise a rendering error")
+
+
+document = render_template(autoescape=True)
+assert [paragraph.text for paragraph in document.paragraphs] == [
+    "Criticality: <select>",
+    "Source: QA",
+]


### PR DESCRIPTION
Refs #634.

This validates rendered XML after Jinja rendering so unescaped context values fail before table recovery can drop text. It also documents the fail-fast behavior in the escaping section and adds a regression script for the `<select>` case, including the successful `autoescape=True` path.

Tests:
- `env/bin/python tests/invalid_xml_after_rendering.py`
- `cd tests && PATH="$PWD/../env/bin:$PATH" ../env/bin/python runtests.py`
- `LC_ALL=C env/bin/python -m flake8 . --exclude=env --jobs=1 --count --max-line-length=127 --show-source --statistics`
