### PR TITLE
fix: allow % and } in {%p %}/{%tr %}/{%tc %}/{%r %} expressions

### DIFF
--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -183,7 +183,7 @@ class DocxTemplate(object):
             # by {% xxx %} or {{ xx }} without any surrounding <w:y> tags :
             # This is mandatory to have jinja2 generating correct xml code
             pat = (
-                r"<w:%(y)s[ >](?:(?!<w:%(y)s[ >]).)*({%%|{{)%(y)s ([^}%%]*(?:%%}|}})).*?</w:%(y)s>"
+                r"<w:%(y)s[ >](?:(?!<w:%(y)s[ >]).)*({%%|{{)%(y)s ((?:(?!%%}|}}).)*(?:%%}|}})).*?</w:%(y)s>"
                 % {"y": y}
             )
             src_xml = re.sub(pat, r"\1 \2", src_xml, flags=re.DOTALL)

--- a/tests/patch_xml_modulo_brace.py
+++ b/tests/patch_xml_modulo_brace.py
@@ -1,0 +1,44 @@
+# Regression test for the {%p %}/{%tr %}/{%tc %}/{%r %} relocation regex.
+#
+# patch_xml() moves a {%p ... %} (or tr/tc/r) directive out of its surrounding
+# <w:p>/<w:tr>/<w:tc>/<w:r> tags. The capture group used to be `[^}%]*`, which
+# stopped at the first "%" or "}" *inside* the expression. As a result a
+# directive whose Jinja expression contained a "%" (e.g. a modulo operation or a
+# literal percent) or a "}" (e.g. a dict literal) was silently left in place,
+# producing invalid XML. The expression is now captured up to the real closing
+# "%}"/"}}", so such expressions round-trip correctly.
+
+from docxtpl import DocxTemplate
+
+# patch_xml() is a pure string transformation and never opens the file, so we
+# can exercise it without a real .docx template.
+tpl = DocxTemplate("dummy.docx")
+
+CASES = [
+    # "%" inside the expression (modulo / literal percent)
+    (
+        "<w:p><w:r><w:t>{%p set x = a % b %}</w:t></w:r></w:p>",
+        "{% set x = a % b %}",
+    ),
+    # "}" inside the expression (dict literal)
+    (
+        "<w:p><w:r><w:t>{%p set d = {'a': 1} %}</w:t></w:r></w:p>",
+        "{% set d = {'a': 1} %}",
+    ),
+    # same fix for a table-row directive carrying a "%"
+    (
+        "<w:tr><w:tc><w:p><w:r><w:t>{%tr for x in items if x % 2 %}"
+        "</w:t></w:r></w:p></w:tc></w:tr>",
+        "{% for x in items if x % 2 %}",
+    ),
+]
+
+for src_xml, expected in CASES:
+    result = tpl.patch_xml(src_xml)
+    assert result == expected, "patch_xml(%r) -> %r, expected %r" % (
+        src_xml,
+        result,
+        expected,
+    )
+
+print("patch_xml_modulo_brace: OK")


### PR DESCRIPTION
Fixes #644.

`patch_xml` matched the expression body of these directive tags with `[^}%]*`, which stops at the first `%` or `}`. Tags whose expression contains a modulo (`if i % 2 == 0`) or a literal brace (`set d = {"x":1}`) were not stripped of their surrounding `<w:p>`/`<w:tr>`/`<w:tc>`/`<w:r>` wrapper, so the literal `{%p ...%}` reached Jinja and raised `TemplateSyntaxError: Encountered unknown tag 'p'`.

The fix matches up to the closing `%}`/`}}` instead of excluding those characters:

```
([^}%%]*(?:%%}|}}))  ->  ((?:(?!%%}|}}).)*(?:%%}|}}))
```

Verified with a real render: a template using `{%p if i % 2 == 0 %}` raises `TemplateSyntaxError` on the current code and renders correctly with the fix. The representative existing fixture tests (dynamic_table, nested_for, vertical_merge, horizontal_merge, less_cells_after_loop, comments, escape, merge_paragraph, richtext, order and others) still pass.

CI runs flake8 only and the existing tests are binary `.docx` fixtures with no assertions, so I did not add a fixture; the reproduction above is in the linked issue. Happy to add a fixture-based test if you prefer.