### PR TITLE
refactor: remove noqa comment from the `__init__` file

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -7,14 +7,13 @@ Created : 2015-03-12
 
 __version__ = "0.20.2"
 __all__ = (
-    "InlineImage",
-    "Listing",
-    "RichText",
-    "R",
-    "RichTextParagraph",
     "RP",
     "DocxTemplate",
-    "Subdoc",
+    "InlineImage",
+    "Listing",
+    "R",
+    "RichText",
+    "RichTextParagraph",
 )
 
 from .inline_image import InlineImage
@@ -24,5 +23,7 @@ from .template import DocxTemplate
 
 try:
     from .subdoc import Subdoc
+
+    __all__ += ("Subdoc",)
 except ImportError:
     pass

--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -6,11 +6,20 @@ Created : 2015-03-12
 """
 
 __version__ = "0.20.2"
+__all__ = (
+    "InlineImage",
+    "Listing",
+    "RichText",
+    "R",
+    "RichTextParagraph",
+    "RP",
+    "DocxTemplate",
+    "Subdoc",
+)
 
-# flake8: noqa
 from .inline_image import InlineImage
 from .listing import Listing
-from .richtext import RichText, R, RichTextParagraph, RP
+from .richtext import RP, R, RichText, RichTextParagraph
 from .template import DocxTemplate
 
 try:


### PR DESCRIPTION
# Description

1. Add `__all__` to `docxtpl/__init__.py` so that the `# noqa` comment is no longer needed.
2. Sort the import statement `from .richtext import ...`.

## Validation results:
- `flake8` check:
```
$ flake8 docxtpl/__init__.py --count --max-line-length=127 --show-source --statistics
0
```
- Expose modules:
```
$ python -c 'from docxtpl import *; print(dir())'
['DocxTemplate', 'InlineImage', 'Listing', 'R', 'RP', 'RichText', 'RichTextParagraph', 'Subdoc', '__annotations__', '__builtins__', '__doc__', '__loader__', '__name__', '__package__', '__spec__']
```
- When `docxcompose` is not installed:
```
$ pip uninstall docxcompose
$ python -c 'from docxtpl import *; print(dir())'
['DocxTemplate', 'InlineImage', 'Listing', 'R', 'RP', 'RichText', 'RichTextParagraph', '__annotations__', '__builtins__', '__doc__', '__loader__', '__name__', '__package__', '__spec__']
```