### PR TITLE
refactor: sort import statements in docxtpl/

### DIFF
--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -7,14 +7,13 @@ Created : 2015-03-12
 
 __version__ = "0.20.2"
 __all__ = (
-    "InlineImage",
-    "Listing",
-    "RichText",
-    "R",
-    "RichTextParagraph",
     "RP",
     "DocxTemplate",
-    "Subdoc",
+    "InlineImage",
+    "Listing",
+    "R",
+    "RichText",
+    "RichTextParagraph",
 )
 
 from .inline_image import InlineImage
@@ -24,5 +23,7 @@ from .template import DocxTemplate
 
 try:
     from .subdoc import Subdoc
+
+    __all__ += ("Subdoc",)
 except ImportError:
     pass

--- a/docxtpl/__init__.py
+++ b/docxtpl/__init__.py
@@ -6,11 +6,20 @@ Created : 2015-03-12
 """
 
 __version__ = "0.20.2"
+__all__ = (
+    "InlineImage",
+    "Listing",
+    "RichText",
+    "R",
+    "RichTextParagraph",
+    "RP",
+    "DocxTemplate",
+    "Subdoc",
+)
 
-# flake8: noqa
 from .inline_image import InlineImage
 from .listing import Listing
-from .richtext import RichText, R, RichTextParagraph, RP
+from .richtext import RP, R, RichText, RichTextParagraph
 from .template import DocxTemplate
 
 try:

--- a/docxtpl/subdoc.py
+++ b/docxtpl/subdoc.py
@@ -5,15 +5,15 @@ Created : 2021-07-30
 @author: Eric Lapouyade
 """
 
-from docx import Document
-from docx.oxml import CT_SectPr
-from docx.opc.constants import RELATIONSHIP_TYPE as RT
-from docxcompose.properties import CustomProperties
-from docxcompose.utils import xpath
-from docxcompose.composer import Composer
-from docxcompose.utils import NS
-from lxml import etree
 import re
+
+from docx import Document
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.oxml import CT_SectPr
+from docxcompose.composer import Composer
+from docxcompose.properties import CustomProperties
+from docxcompose.utils import NS, xpath
+from lxml import etree
 
 
 class SubdocComposer(Composer):

--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -6,28 +6,29 @@ Created : 2015-03-12
 """
 from __future__ import annotations
 
-from os import PathLike
-from typing import TYPE_CHECKING, Any, Optional, IO, Union, Dict, Set
+import binascii
 import functools
 import io
-from lxml import etree
+import os
+import re
+import zipfile
+from os import PathLike
+from typing import IO, TYPE_CHECKING, Any, Dict, Optional, Set, Union
+
+import docx.oxml.ns
 from docx import Document
+from docx.opc.constants import RELATIONSHIP_TYPE as REL_TYPE
 from docx.opc.oxml import parse_xml
 from docx.opc.part import XmlPart
-import docx.oxml.ns
-from docx.opc.constants import RELATIONSHIP_TYPE as REL_TYPE
 from jinja2 import Environment, Template, meta
 from jinja2.exceptions import TemplateError
+from lxml import etree
 
 try:
     from html import escape  # noqa: F401
 except ImportError:
     # cgi.escape is deprecated in python 3.7
     from cgi import escape  # noqa: F401
-import re
-import binascii
-import os
-import zipfile
 
 if TYPE_CHECKING:
     from .subdoc import Subdoc


### PR DESCRIPTION
# Description

1. Relocate the `try ... except ImportError` block in `docxtpl/template.py` to below the other import statements.
2. Reorder imports with `isort` (run `uvx isort docxtpl`).

This is based on PR #647. 
Diff: https://github.com/waketzheng/python-docx-template/compare/remove-noqa...sort-imports
