### PR TITLE
Fix test runner to use current Python and report failures

### DIFF
--- a/tests/module_execute.py
+++ b/tests/module_execute.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 
 TEMPLATE_PATH = "templates/module_execute_tpl.docx"
 JSON_PATH = "templates/module_execute.json"
@@ -11,15 +13,18 @@ if os.path.exists(OUTPUT_FILENAME):
     os.unlink(OUTPUT_FILENAME)
 
 os.chdir(os.path.dirname(__file__))
-cmd = "python -m docxtpl %s %s %s %s %s" % (
+cmd = [
+    sys.executable,
+    "-m",
+    "docxtpl",
     TEMPLATE_PATH,
     JSON_PATH,
     OUTPUT_FILENAME,
     OVERWRITE,
     QUIET,
-)
-print('Executing "%s" ...' % cmd)
-os.system(cmd)
+]
+print('Executing "%s" ...' % " ".join(cmd))
+subprocess.run(cmd, check=True)
 
 if os.path.exists(OUTPUT_FILENAME):
     print("    --> File %s has been generated." % OUTPUT_FILENAME)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,17 +1,28 @@
 import subprocess
 import glob
 import os
+import sys
 
-tests = sorted(glob.glob("[A-Za-z]*.py"))
+tests_dir = os.path.dirname(__file__)
+tests = sorted(glob.glob(os.path.join(tests_dir, "[A-Za-z]*.py")))
 excludes = ["runtests.py"]
 
-output_dir = os.path.join(os.path.dirname(__file__), "output")
+output_dir = os.path.join(tests_dir, "output")
 if not os.path.exists(output_dir):
     os.mkdir(output_dir)
 
+failed = []
+
 for test in tests:
-    if test not in excludes:
-        print("%s ..." % test)
-        subprocess.call(["python", "./%s" % test])
+    test_name = os.path.basename(test)
+    if test_name not in excludes:
+        print("%s ..." % test_name)
+        completed = subprocess.run([sys.executable, "./%s" % test_name], cwd=tests_dir)
+        if completed.returncode:
+            failed.append(test_name)
+
+if failed:
+    print("Failed: %s" % ", ".join(failed))
+    sys.exit(1)
 
 print("Done.")


### PR DESCRIPTION
### Summary
- Run test scripts with `sys.executable` so the active virtualenv/CI Python is preserved.
- Resolve test files relative to the `tests/` directory, allowing `python tests/runtests.py` from the repo root.
- Exit non-zero when any test script fails.
- Replace `os.system("python -m docxtpl ...")` with `subprocess.run(..., check=True)`.

### Verification
- `python tests/runtests.py`
- `python -m flake8 docxtpl tests setup.py --count --max-line-length=127 --show-source --statistics`
