### PR TITLE
docs: clarify dictionary method keys

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,6 +136,13 @@ Note the ``r`` right after the opening braces.
 
 **VERY IMPORTANT :** Variables must not contains characters like ``<``, ``>`` and ``&`` unless using Escaping_
 
+Dictionary keys named like dictionary methods must use bracket notation. For
+example, use ``{{ soil['pop'] }}`` for ``context = {'soil': {'pop': 2}}``.
+``{{ soil.pop }}`` resolves to the dictionary ``pop`` method instead of the
+``'pop'`` key. With autoescaping disabled, rendering that method representation
+can produce invalid XML; ``autoescape=True`` prevents the invalid XML but does
+not select the dictionary key for you.
+
 **IMPORTANT :** Always put space after a starting var delimiter and a space before the ending one :
 
 Avoid::


### PR DESCRIPTION
## Summary
- Document bracket notation for dictionary keys that collide with dictionary methods.
- Clarify that autoescaping can prevent invalid XML but does not select the mapping key.

## Why
`{{ soil.pop }}` resolves to the dictionary method rather than the `pop` context key. `{{ soil['pop'] }}` renders the intended value.

Fixes #496

## Validation
- `git diff --check`
- Rendered a temporary DOCX with `{{ soil['pop'] }}` and confirmed that it reopens with the expected value.