### PR TITLE
Expand self-closing tcPr before inserting gridSpan and shd

### DIFF
--- a/docxtpl/template.py
+++ b/docxtpl/template.py
@@ -120,6 +120,13 @@ class DocxTemplate(object):
                 flags=re.DOTALL,
             )
             cell_xml = re.sub(r"<w:gridSpan[^/]*/>", "", cell_xml, count=1)
+            # a self-closing <w:tcPr/> would leave the inserted gridSpan outside of it
+            cell_xml = re.sub(
+                r"<w:tcPr(\s[^>]*)?/>",
+                lambda mm: "<w:tcPr%s></w:tcPr>" % (mm.group(1) or ""),
+                cell_xml,
+                count=1,
+            )
             return re.sub(
                 r"(<w:tcPr[^>]*>)",
                 r'\1<w:gridSpan w:val="{{%s}}"/>' % m.group(2),
@@ -143,6 +150,13 @@ class DocxTemplate(object):
                 flags=re.DOTALL,
             )
             cell_xml = re.sub(r"<w:shd[^/]*/>", "", cell_xml, count=1)
+            # a self-closing <w:tcPr/> would leave the inserted shd outside of it
+            cell_xml = re.sub(
+                r"<w:tcPr(\s[^>]*)?/>",
+                lambda mm: "<w:tcPr%s></w:tcPr>" % (mm.group(1) or ""),
+                cell_xml,
+                count=1,
+            )
             return re.sub(
                 r"(<w:tcPr[^>]*>)",
                 r'\1<w:shd w:val="clear" w:color="auto" w:fill="{{%s}}"/>' % m.group(2),

--- a/tests/cellbg_selfclosing.py
+++ b/tests/cellbg_selfclosing.py
@@ -1,0 +1,42 @@
+# Regression test for #559: pandoc-produced tables collapse empty cell
+# properties to a self-closing <w:tcPr/>, which used to make cellbg and
+# colspan insert <w:shd>/<w:gridSpan> as a sibling after it instead of
+# inside, so Word silently ignored them. No template file needed, the
+# checks work on patch_xml output directly.
+
+import re
+
+from docxtpl import DocxTemplate
+
+tpl = DocxTemplate("dummy.docx")
+
+
+def patched(body):
+    return tpl.patch_xml("<w:tbl><w:tr><w:tc>%s</w:tc></w:tr></w:tbl>" % body)
+
+
+def assert_inside_tcpr(xml, element):
+    m = re.search(r"<w:tcPr[^/>]*>(.*?)</w:tcPr>", xml, flags=re.DOTALL)
+    assert m, "no expanded <w:tcPr> pair in: %s" % xml
+    assert element in m.group(1), "%s not inside <w:tcPr>: %s" % (element, xml)
+
+
+# self-closing <w:tcPr/> (the #559 case)
+xml = patched("<w:tcPr/><w:p><w:r><w:t>{% cellbg color %}x</w:t></w:r></w:p>")
+assert_inside_tcpr(xml, "<w:shd ")
+
+xml = patched("<w:tcPr/><w:p><w:r><w:t>{% colspan span %}x</w:t></w:r></w:p>")
+assert_inside_tcpr(xml, "<w:gridSpan ")
+
+# self-closing with attributes
+xml = patched('<w:tcPr w:dummy="1"/><w:p><w:r><w:t>{% cellbg color %}x</w:t></w:r></w:p>')
+assert_inside_tcpr(xml, "<w:shd ")
+
+# already expanded <w:tcPr> keeps working as before
+xml = patched(
+    '<w:tcPr><w:tcW w:w="100"/></w:tcPr><w:p><w:r><w:t>{% cellbg color %}x</w:t></w:r></w:p>'
+)
+assert_inside_tcpr(xml, "<w:shd ")
+assert_inside_tcpr(xml, "<w:tcW ")
+
+print("cellbg_selfclosing ok")


### PR DESCRIPTION
Fixes #559.

Pandoc (and some other producers) collapse empty cell properties to a self-closing `<w:tcPr/>`. The insertion regex in `colspan()` and `cellbg()` matches that form too (`[^>]*` eats the `/`), so `<w:gridSpan>` / `<w:shd>` end up as a sibling after the closed element instead of inside it. That position is schema-invalid and Word silently drops it, which matches the silent breakage reported in the issue.

The fix expands a self-closing `<w:tcPr/>` (attributes preserved) into an open/close pair before the existing insertion runs. Templates that already have an expanded `<w:tcPr>` go through exactly the same path as before.

Added tests/cellbg_selfclosing.py covering cellbg and colspan against a self-closing tcPr, one with attributes, and the already-expanded form. It asserts on patch_xml output directly so it needs no template file. Ran the rest of the tests dir locally, all green.