### PR TITLE
Fix core properties namespace conflict

### DIFF
--- a/docxtpl/subdoc.py
+++ b/docxtpl/subdoc.py
@@ -7,6 +7,7 @@ Created : 2021-07-30
 
 from docx import Document
 from docx.oxml import CT_SectPr
+from docx.oxml.ns import nsmap
 from docx.opc.constants import RELATIONSHIP_TYPE as RT
 from docxcompose.properties import CustomProperties
 from docxcompose.utils import xpath
@@ -14,6 +15,12 @@ from docxcompose.composer import Composer
 from docxcompose.utils import NS
 from lxml import etree
 import re
+
+
+# docxcompose changes python-docx's process-wide ``cp`` prefix to the custom
+# properties namespace. Restore its standard meaning so python-docx updates
+# existing core properties instead of adding conflicting elements.
+nsmap["cp"] = "http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
 
 
 class SubdocComposer(Composer):

--- a/tests/core_properties.py
+++ b/tests/core_properties.py
@@ -1,0 +1,27 @@
+from zipfile import ZipFile
+
+from lxml import etree
+
+from docxtpl import DocxTemplate
+
+doctemplate = r"templates/doc_properties_tpl.docx"
+output = "output/core_properties.docx"
+
+tpl = DocxTemplate(doctemplate)
+tpl.render({"test": "HelloWorld"})
+tpl.docx.core_properties.keywords = "rendered by docxtpl"
+tpl.save(output)
+
+with ZipFile(output) as archive:
+    core_properties = etree.fromstring(archive.read("docProps/core.xml"))
+
+keywords = [
+    element
+    for element in core_properties
+    if etree.QName(element).localname == "keywords"
+]
+assert len(keywords) == 1
+assert etree.QName(keywords[0]).namespace == (
+    "http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+)
+assert keywords[0].text == "rendered by docxtpl"


### PR DESCRIPTION
## Summary

Importing `docxtpl` also imports `docxcompose` when the subdocument extra is installed. `docxcompose.utils` changes the process-wide python-docx `nsmap["cp"]` entry to the custom-properties namespace. Later core-property assignments then append an element in that namespace instead of updating the existing core property.

This restores the standard core-properties mapping after the docxcompose imports. docxcompose keeps its own `NS` mapping, so its custom-property and subdocument behavior is unchanged.

The regression test renders a template, sets `keywords`, then inspects `docProps/core.xml` and verifies there is exactly one keyword element in the standard core-properties namespace.

Fixes #471

## Verification

- All 37 repository test scripts pass individually
- Full flake8 target passes
- Source distribution and wheel build successfully
- Core-property, custom-property, and subdocument smoke tests pass with docxcompose 1.4.1 and 2.2.0